### PR TITLE
Remove usage of UUID's and use SQLite's internal rowid as a primary key instead

### DIFF
--- a/src/lib/server/db/__generated__/types.d.ts
+++ b/src/lib/server/db/__generated__/types.d.ts
@@ -5,51 +5,51 @@
 
 export interface Card {
   data: string;
+  id: number;
   name: string;
   oracleId: string;
-  uuid: string;
 }
 
 export interface Commander {
   colorId: string;
+  id: number;
   name: string;
-  uuid: string;
 }
 
 export interface DecklistItem {
-  cardUuid: string;
-  entryUuid: string;
+  cardId: number;
+  entryId: number;
 }
 
 export interface Entry {
-  commanderUuid: string;
+  commanderId: number;
   decklist: string | null;
   draws: number;
+  id: number;
   lossesBracket: number;
   lossesSwiss: number;
-  playerUuid: string;
+  playerId: number;
   standing: number;
-  tournamentUuid: string;
-  uuid: string;
+  tournamentId: number;
   winsBracket: number;
   winsSwiss: number;
 }
 
 export interface Player {
+  id: number;
   name: string;
   topdeckProfile: string | null;
-  uuid: string;
 }
 
 export interface Tournament {
   bracketUrl: string | null;
+  id: number;
   name: string;
   size: number;
   swissRounds: number;
   TID: string;
   topCut: number;
   tournamentDate: string;
-  uuid: string;
 }
 
 export interface DB {

--- a/src/lib/server/schema/card.ts
+++ b/src/lib/server/schema/card.ts
@@ -3,18 +3,18 @@ import { scryfallCardSchema } from "../scryfall";
 import { builder } from "./builder";
 
 export const Card = builder.loadableNode("Card", {
-  id: { resolve: (parent) => parent.uuid },
-  load: async (ids: string[]) => {
+  id: { resolve: (parent) => parent.id },
+  load: async (ids: number[]) => {
     const nodes = await db
       .selectFrom("Card")
       .selectAll()
-      .where("uuid", "in", ids)
+      .where("id", "in", ids)
       .execute();
 
-    const nodesByUuid = new Map<string, (typeof nodes)[number]>();
-    for (const node of nodes) nodesByUuid.set(node.uuid, node);
+    const nodesById = new Map<number, (typeof nodes)[number]>();
+    for (const node of nodes) nodesById.set(node.id, node);
 
-    return ids.map((id) => nodesByUuid.get(id)!);
+    return ids.map((id) => nodesById.get(id)!);
   },
   fields: (t) => ({
     name: t.exposeString("name"),

--- a/src/lib/server/schema/types.ts
+++ b/src/lib/server/schema/types.ts
@@ -40,7 +40,7 @@ export const TopdeckTournamentTableType = builder.objectRef<
 >("TopdeckTournamentTable");
 
 export const TournamentBreakdownGroupType = builder.objectRef<{
-  commanderUuid: string;
+  commanderId: number;
   topCuts: number;
   entries: number;
   conversionRate: number;

--- a/src/queries/schema.graphql
+++ b/src/queries/schema.graphql
@@ -242,6 +242,7 @@ type TournamentBreakdownGroup {
 }
 
 input TournamentFilters {
+  maxDate: String
   maxSize: Int
   minDate: String
   minSize: Int


### PR DESCRIPTION
This shaves a good 20 seconds off of seed time and should improve query performance all around.