### PR TITLE
Exclude specific spicerack tournaments from database ingestion

### DIFF
--- a/scripts/generate-database.ts
+++ b/scripts/generate-database.ts
@@ -16,6 +16,9 @@ import * as undici from 'undici';
 import {z} from 'zod/v4';
 import {ScryfallCard, scryfallCardSchema} from '../src/lib/server/scryfall';
 
+/** Tournament IDs to exclude from ingestion */
+const EXCLUDED_TOURNAMENT_IDS = ['spicerack:2269579', 'spicerack:2269574', 'spicerack:2269571'];
+
 const args = parseArgs({
   options: {
     tid: {
@@ -180,9 +183,11 @@ async function getTournaments(
     jsonImportedSchema,
   ]);
 
-  const metadataFilters: Record<string, unknown> = {};
+  const metadataFilters: Record<string, unknown> = {
+    TID: {$nin: EXCLUDED_TOURNAMENT_IDS}
+  };
   if (tids) {
-    metadataFilters.TID = {$in: tids};
+    metadataFilters.TID = {$in: tids, $nin: EXCLUDED_TOURNAMENT_IDS};
   }
 
   const tournaments = mongo


### PR DESCRIPTION
## Summary
- Exclude tournaments spicerack:2269579, spicerack:2269574, and spicerack:2269571 from database ingestion
- Added `EXCLUDED_TOURNAMENT_IDS` constant for easy identification and maintenance
- Modified `getTournaments` function to filter out these tournaments from both general queries and specific TID queries

## Test plan
- [ ] Verify the excluded tournament IDs are properly filtered during database generation
- [ ] Confirm that other tournaments continue to be ingested normally
- [ ] Test with specific TID queries to ensure exclusion logic works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)