### PR TITLE
Fix staples type filter select width

### DIFF
--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -25,7 +25,7 @@ export function Select({
           id={id}
           value={value}
           disabled={disabled}
-          className="w-full appearance-none bg-white"
+          className="w-full bg-white"
           onChange={(e) => {
             onChange?.(e.target.value);
           }}

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -20,12 +20,12 @@ export function Select({
         {label}
       </label>
 
-      <div className="rounded-xl bg-white p-2 text-sm">
+      <div className="w-full rounded-xl bg-white p-2 text-sm">
         <select
           id={id}
           value={value}
           disabled={disabled}
-          className="bg-white"
+          className="w-full appearance-none bg-white"
           onChange={(e) => {
             onChange?.(e.target.value);
           }}


### PR DESCRIPTION
## Summary
- make the Select component expand to full width so the dropdown arrow stays right-aligned on mobile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d792c45fe48333b2df581500b37b73